### PR TITLE
Add a simple http webserver for working locally.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+node_modules/

--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "sechelt",
+  "version": "0.0.1",
+  "description": "Sechelt",
+  "scripts": {
+    "start": "http-server ./"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/mozvr/sechelt.git"
+  },
+  "license": "MPL",
+  "bugs": {
+    "url": "https://github.com/mozvr/sechelt/issues"
+  },
+  "engines": {
+    "node": "0.12.x"
+  },
+  "devDependencies": {
+    "http-server": "^0.7.4"
+  }
+}


### PR DESCRIPTION
This will make `npm start` run a webserver for local testing. This helps me test some stuff as our browser doesn't yet support the file:// protocol.

@caseyyee - Could you review/land this if it looks ok?
