### PR TITLE
Fixes #10: set texture.minFilter to THREE.minFilter

### DIFF
--- a/js/sechelt.js
+++ b/js/sechelt.js
@@ -79,13 +79,16 @@ function init() {
 
 	}
 
+  var texture = THREE.ImageUtils.loadTexture('images/bg-2.png');
+  texture.minFilter = THREE.LinearFilter;
+
 	var material = new THREE.MeshBasicMaterial({
 		//vertexColors: THREE.VertexColors,
 		side: THREE.BackSide,
 		depthWrite: false,
 		depthTest: false,
 		fog: false,
-		map: THREE.ImageUtils.loadTexture('images/bg-2.png')
+		map: texture
 	});
 
 	sky = new THREE.Mesh(geometry, material);


### PR DESCRIPTION
Remove warning for texture size to be a power of two.
